### PR TITLE
slack-handler: usability fixes

### DIFF
--- a/lib/slack-handler.js
+++ b/lib/slack-handler.js
@@ -12,7 +12,8 @@ var HELPERS = {
     } catch(e) {
       context.logger.warn('Failed to parse channel config', e);
     }
-    return channelConfig.channelName || ('#' + slackChannel.name);
+    return channelConfig.channelName ||
+           (slackChannel.name == 'general' ? '' : '#' + slackChannel.name);
   },
   parseConfig: function parseConfig(configString) {
     return JSON.parse(configString.replace(/[\u201C-\u201D]/g, '"'));
@@ -26,11 +27,15 @@ var SLACK_EVENTS = {
 
     // Prepare IRC connection
     var user = context.slack.client.data.getUserById(context.slack.client.rtm.activeUserId);
+    context.logger.debug('IRC config -> '+user.profile.title);
     var userConfig = HELPERS.parseConfig(user.profile.title);
     // TODO: Fetch channel config from channel purpose
     var userChannels = _.chain(context.slack.client.data.channels)
                     .filter('is_member')
                     .map(HELPERS.getIrcChannelName.bind(null, context))
+                    .filter(function(channel) {
+                      return channel.name !== '';
+                    })
                     .valueOf();
 
     context.irc.options = {

--- a/lib/slack-handler.js
+++ b/lib/slack-handler.js
@@ -48,7 +48,7 @@ var SLACK_EVENTS = {
     context.irc.options = {
       server: userConfig.server,
       port: userConfig.port || 6667,
-      nick: user.name,
+      nick: userConfig.userName || user.name,
       realName: user.realName,
       channels: userChannels
     };

--- a/lib/slack-handler.js
+++ b/lib/slack-handler.js
@@ -6,7 +6,10 @@ var HELPERS = {
   getIrcChannelName: function getIrcChannelName(context, slackChannel) {
     var channelConfig = {};
     try {
-      if (slackChannel.purpose && slackChannel.purpose.value) {
+      if (slackChannel.purpose && slackChannel.purpose.value &&
+          HELPERS.detectJsonString(slackChannel.purpose.value)) {
+        context.logger.debug('Channel info -> name='+slackChannel.name+
+                               ' purpose='+slackChannel.purpose.value);
         channelConfig = HELPERS.parseConfig(slackChannel.purpose.value) || {};
       }
     } catch(e) {
@@ -17,6 +20,10 @@ var HELPERS = {
   },
   parseConfig: function parseConfig(configString) {
     return JSON.parse(configString.replace(/[\u201C-\u201D]/g, '"'));
+  },
+  detectJsonString: function (configString) {
+    var trimmed_str = configString.trim();
+    return trimmed_str.startsWith('[') || trimmed_str.startsWith('{');
   }
 };
 


### PR DESCRIPTION
- Ignore joining channel "general" when purpose field is not set
- Avoid logging errors when strings start with JSON legal characters
- Use username of "userName" config value when set
