### PR TITLE
Do not send CTCP notifications for actions

### DIFF
--- a/lib/irc-handler.js
+++ b/lib/irc-handler.js
@@ -214,9 +214,11 @@ var IRC_EVENTS = {
     context.logger.verbose('IRC: Received CTCP notice from %s', from, text);
     HELPERS.sendUser(context, 'CTCP notice from ' + from, text);
   },
-  'ctcp-privmsg': function ctcpVersion(context, from, to, text, message) {
-    context.logger.verbose('IRC: Received CTCP privmsg from %s', from, text);
-    HELPERS.sendUser(context, 'CTCP notice from ' + from, text);
+  'ctcp-privmsg': function ctcpPrivmsg(context, from, to, text, message) {
+    context.logger.verbose('IRC: Received CTCP privmsg from %s to %s', from, to, text);
+    if (text.split(' ')[0] !== 'ACTION') {
+      HELPERS.sendUser(context, 'CTCP notice from ' + from, text);
+    }
   },
   'ctcp-version': function ctcpVersion(context, from, to, message) {
     context.logger.verbose('IRC: Received CTCP VERSION from %s', from);


### PR DESCRIPTION
- Actions on IRC seem to send both an action and a CTCP ACTION
- The latter is rather annoying since it goes straight to Slackbot and sends notifications for it

What it looked like in logs:

```
verbose: IRC: Received CTCP privmsg from yokuyuki to #test ACTION rolls
verbose: IRC: New action from yokuyuki to #test: rolls
```
- This change mutes that CTCP
