### PR TITLE
Adds Dockerfile and start.sh to allow for passing slack token as ENV var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:6
+RUN npm install -g slack-irc-client
+ADD bin/start.sh /start.sh
+ENTRYPOINT /start.sh

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if test -z "$SLACK_TOKEN"; then
+	echo "Set your SLACK_TOKEN environment variable"
+	exit 1
+fi
+slack-irc-client -t $SLACK_TOKEN


### PR DESCRIPTION
I've published this at dockerhub under imartyn/slack-irc-client, and it works for me.