### PR TITLE
Make notices be channel status messages instead of DM

### DIFF
--- a/lib/irc-handler.js
+++ b/lib/irc-handler.js
@@ -240,7 +240,11 @@ var IRC_EVENTS = {
   },
   notice: function notice(context, nick, to, text, message) {
     context.logger.verbose('IRC: New notice from %s: %s', nick, text);
-    HELPERS.sendUser(context, 'Notice from ' + nick, text);
+    if (HELPERS.isIrcChannel(context, to)) {
+      HELPERS.sendChannelStatus(context, to, 'Notice from ' + nick + ': ' + text);
+    } else {
+      HELPERS.sendGroup(context, nick, 'Notice from ' + nick, text);
+    }
   },
   'ctcp-notice': function ctcpVersion(context, from, to, text, message) {
     context.logger.verbose('IRC: Received CTCP notice from %s', from, text);


### PR DESCRIPTION
This fixes the major painpoints of #29 by keeping notices in the channels themselves, which means you aren't spammed with unmutable DM messages.

Let me know if you prefer some other approach to this, or would prefer this was configurable.