### PR TITLE
Fix toLowerCase of undefined error on sendGroup from notice

### DIFF
--- a/lib/irc-handler.js
+++ b/lib/irc-handler.js
@@ -243,7 +243,7 @@ var IRC_EVENTS = {
     if (HELPERS.isIrcChannel(context, to)) {
       HELPERS.sendChannelStatus(context, to, 'Notice from ' + nick + ': ' + text);
     } else {
-      HELPERS.sendGroup(context, nick, 'Notice from ' + nick, text);
+      HELPERS.sendUser(context, 'Notice from ' + nick, text);
     }
   },
   'ctcp-notice': function ctcpVersion(context, from, to, text, message) {

--- a/lib/irc-handler.js
+++ b/lib/irc-handler.js
@@ -240,7 +240,11 @@ var IRC_EVENTS = {
   },
   notice: function notice(context, nick, to, text, message) {
     context.logger.verbose('IRC: New notice from %s: %s', nick, text);
-    HELPERS.sendUser(context, 'Notice from ' + nick, text);
+    if (HELPERS.isIrcChannel(context, to)) {
+      HELPERS.sendChannelStatus(context, to, 'Notice from ' + nick + ': ' + text);
+    } else {
+      HELPERS.sendGroup(context, nick, 'Notice from ' + nick, text);
+    }
   },
   'ctcp-notice': function ctcpVersion(context, from, to, text, message) {
     context.logger.verbose('IRC: Received CTCP notice from %s', from, text);


### PR DESCRIPTION
I started getting a bit of errors after my last PR (included in the bottom), probably because I didn't quite understand what `sendGroup` was doing. This reverts the notices that are not channel notices back to being sent to the user, for now.

The messages affected are the server messages on connection/login, e.q.

```
Notice from undefined
*** Found your hostname
```

So it shouldn't be that bad :)


The errors:

```
error: Failed to handle IRC event notice TypeError: Cannot read property 'toLowerCase' of undefined
    at Object.sendGroup (/home/tehnix/GitHub/Forks/slack-irc-client/lib/irc-handler.js:104:27)
    at notice (/home/tehnix/GitHub/Forks/slack-irc-client/lib/irc-handler.js:246:15)
    at Client.handler._boundListener (/home/tehnix/GitHub/Forks/slack-irc-client/lib/irc-handler.js:313:24)
    at emitMany (events.js:146:13)
    at Client.emit (events.js:223:7)
    at Client.<anonymous> (/home/tehnix/GitHub/Forks/slack-irc-client/node_modules/irc/lib/irc.js:256:22)
    at emitOne (events.js:120:20)
    at Client.emit (events.js:210:7)
    at iterator (/home/tehnix/GitHub/Forks/slack-irc-client/node_modules/irc/lib/irc.js:846:26)
    at Array.forEach (<anonymous>)
    at TLSSocket.handleData (/home/tehnix/GitHub/Forks/slack-irc-client/node_modules/irc/lib/irc.js:841:15)
    at emitOne (events.js:115:13)
    at TLSSocket.emit (events.js:210:7)
    at addChunk (_stream_readable.js:264:12)
    at readableAddChunk (_stream_readable.js:247:13)
    at TLSSocket.Readable.push (_stream_readable.js:209:10)
```