### PR TITLE
More mutable events

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,19 +113,34 @@ For example:
 This can also be used if you just want the channel name to show differently within Slack.
 
 
-#### Ignoring JOIN, PART, QUIT etc
+#### Ignoring JOIN, PART, QUIT, etc.
 
-To ignore JOINs, PARTs, QUITs, KICKs and KILLs you can configure your `What I do` JSON object to include,
+To ignore various messages, you can configure your `What I do` JSON object to
+include the `muteIrcEvents` field:
 
 ```json
 {
   "server": "open.ircnet.net",
   // ...
-  "muteIrcEvents": ["join", "part", "quit", "kick", "kill"]
+  "muteIrcEvents": ["join", ...]
 }
 ```
 
 And you'll no longer see these messages in your Slack channels.
+
+Valid values for this field are as follows:
+
+| Value   | Description                                     |
+| ------- | ----------------------------------------------- |
+| `join`  | Mute JOIN messages in the channel               |
+| `kick`  | Mute KICK messages in the channel               |
+| `kill`  | Mute KILL messages in the channel               |
+| `motd`  | Mute MOTD direct messages from slackbot on join |
+| `names` | Mute membership list in the channel on join     |
+| `part`  | Mute PART messages in the channel               |
+| `quit`  | Mute QUIT messages in the channel               |
+| `topic` | Don't set the topic in the channel on join      |
+
 
 #### Sending direct messages
 

--- a/lib/irc-handler.js
+++ b/lib/irc-handler.js
@@ -168,12 +168,18 @@ var IRC_EVENTS = {
   },
   motd: function motd(context, motd) {
     context.logger.verbose('IRC: MOTD', motd);
-    HELPERS.sendUser(context, 'Message of the Day', motd);
+    // Only send the MOTD to slack if it isn't ignored.
+    if (HELPERS.isNotMuted(context, 'join')) {
+      HELPERS.sendUser(context, 'Message of the Day', motd);
+    }
   },
   names: function names(context, channel, nicks) {
     var nickNames = Object.keys(nicks).join(', ');
     context.logger.verbose('IRC: Channel names for %s: %s', channel, nickNames);
-    HELPERS.sendChannelStatus(context, channel, 'members: ' + nickNames);
+    // Only send the members to slack if it isn't ignored.
+    if (HELPERS.isNotMuted(context, 'names')) {
+      HELPERS.sendChannelStatus(context, channel, 'members: ' + nickNames);
+    }
   },
   topic: function topic(context, channel, topic, nick, message) {
     if (nick === context.irc.client.nick) {
@@ -181,7 +187,10 @@ var IRC_EVENTS = {
       return;
     }
     context.logger.verbose('IRC: Topic set for %s by %s to %s', channel, nick, topic);
-    HELPERS.setTopic(context, channel, topic);
+    // Only send the topic to slack if it isn't ignored.
+    if (HELPERS.isNotMuted(context, 'topic')) {
+      HELPERS.setTopic(context, channel, topic);
+    }
   },
   join: function join(context, channel, nick, message) {
     context.logger.verbose('IRC: %s joined %s', nick, channel);


### PR DESCRIPTION
This PR makes the MOTD, topic and "names" events mutable via the config, and documents all mutable events in the README.